### PR TITLE
GLPK performance

### DIFF
--- a/pmedian.jl
+++ b/pmedian.jl
@@ -209,9 +209,11 @@ function solve_scs_direct(data::PMedianData; max_iters)
 end
 
 function solve_moi(data::PMedianData, optimizer; params)
-    model = MOI.Bridges.full_bridge_optimizer(MOI.Utilities.CachingOptimizer(
+    cached = MOI.Utilities.CachingOptimizer(
         MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
-        optimizer()), Float64)
+        optimizer())
+    model = MOI.Bridges.full_bridge_optimizer(cached, Float64)
+    MOI.Utilities.reset_optimizer(cached)
     for (param, value) in params
         MOI.set(model, param, value)
     end
@@ -268,4 +270,4 @@ run_benchmark(num_facilities=5, num_customers=20, num_locations=10,
     time_limit_sec=Inf, max_iters=10000)
 
 run_benchmark(num_facilities=10, num_customers=2000, num_locations=1000,
-    time_limit_sec=5, max_iters=10)
+    time_limit_sec=1, max_iters=10)

--- a/pmedian.jl
+++ b/pmedian.jl
@@ -213,6 +213,9 @@ function solve_moi(data::PMedianData, optimizer; params)
         MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
         optimizer())
     model = MOI.Bridges.full_bridge_optimizer(cached, Float64)
+    # resetting optimizer is necessary to use copy_to to transfer all the data
+    # from caching optimizer to GLPK in a single batch. If that is not called
+    # constraints are passed one by one during model generation phase.
     MOI.Utilities.reset_optimizer(cached)
     for (param, value) in params
         MOI.set(model, param, value)
@@ -237,8 +240,6 @@ function solve_scs_moi(data::PMedianData; max_iters)
               (MOI.RawParameter("acceleration_lookback"), 0)]
     @timeit "SCS MOI" solve_moi(data, SCS.Optimizer, params=params)
 end
-
-
 
 function run_benchmark(;num_facilities, num_customers, num_locations,
         time_limit_sec, max_iters)


### PR DESCRIPTION
Depends on:
https://github.com/jump-dev/MathOptInterface.jl/pull/1129
https://github.com/jump-dev/GLPK.jl/pull/143
latest measurements:
```julia
 ──────────────────────────────────────────────────────────────────────
                               Time                   Allocations
                       ──────────────────────   ───────────────────────
   Tot / % measured:       3.17ms / 84.5%            516KiB / 99.2%

 Section       ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────────
 GLPK MOI           1   1.72ms  64.4%  1.72ms    476KiB  92.9%   476KiB
   solve            1   1.39ms  52.1%  1.39ms    333KiB  65.0%   333KiB
   generate         1   92.3μs  3.45%  92.3μs    112KiB  21.9%   112KiB
 GLPK direct        1    951μs  35.6%   951μs   36.2KiB  7.06%  36.2KiB
   solve            1    898μs  33.6%   898μs     0.00B  0.00%    0.00B
   generate         1   43.0μs  1.61%  43.0μs   34.2KiB  6.67%  34.2KiB
 ──────────────────────────────────────────────────────────────────────

 ──────────────────────────────────────────────────────────────────────
                               Time                   Allocations
                       ──────────────────────   ───────────────────────
   Tot / % measured:        11.5s / 100%            2.40GiB / 100%

 Section       ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────────
 GLPK MOI           1    7.50s  65.4%   7.50s   2.27GiB  94.4%  2.27GiB
   solve            1    6.30s  55.0%   6.30s   1.43GiB  59.7%  1.43GiB
   generate         1    1.20s  10.4%   1.20s    853MiB  34.7%   853MiB
 GLPK direct        1    3.97s  34.6%   3.97s    139MiB  5.64%   139MiB
   solve            1    2.56s  22.3%   2.56s     0.00B  0.00%    0.00B
   generate         1    1.23s  10.7%   1.23s    139MiB  5.64%   139MiB
 ──────────────────────────────────────────────────────────────────────
```
before that:
```julia
 ──────────────────────────────────────────────────────────────────────
                               Time                   Allocations
                       ──────────────────────   ───────────────────────
   Tot / % measured:       3.33ms / 89.4%            841KiB / 100%

 Section       ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────────
 GLPK MOI           1   2.03ms  68.1%  2.03ms    800KiB  95.7%   800KiB
   solve            1   1.74ms  58.5%  1.74ms    658KiB  78.7%   658KiB
   generate         1   78.2μs  2.63%  78.2μs    112KiB  13.4%   112KiB
 GLPK direct        1    949μs  31.9%   949μs   36.2KiB  4.32%  36.2KiB
   solve            1    907μs  30.5%   907μs     0.00B  0.00%    0.00B
   generate         1   34.7μs  1.17%  34.7μs   34.2KiB  4.08%  34.2KiB
 ──────────────────────────────────────────────────────────────────────

 ──────────────────────────────────────────────────────────────────────
                               Time                   Allocations
                       ──────────────────────   ───────────────────────
   Tot / % measured:        21.8s / 100%            5.42GiB / 100%

 Section       ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────────
 GLPK MOI           1    17.7s  81.5%   17.7s   5.28GiB  97.5%  5.28GiB
   solve            1    16.4s  75.3%   16.4s   4.44GiB  82.0%  4.44GiB
   generate         1    1.28s  5.90%   1.28s    853MiB  15.4%   853MiB
 GLPK direct        1    4.02s  18.5%   4.02s    139MiB  2.50%   139MiB
   solve            1    2.41s  11.1%   2.41s     0.00B  0.00%    0.00B
   generate         1    1.46s  6.70%   1.46s    139MiB  2.50%   139MiB
 ──────────────────────────────────────────────────────────────────────
```